### PR TITLE
[REVROBO-19] Implement support of crash reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,12 @@ Application supports the following parameters
 * `--host` specifies IP address if the SPARK-MAX server
 * `--port` specifies port of the SPAstaRK-MAX server
 * `--remote`. When `--remote` flag is set, application does not try to start bundled SPARK-MAX server and connects to the specified one (through `--host` and `--port` parameters).
-* `---grpc`. When `--grpc` flag is set, application runs gRPC client instead of ZeroMQ (default). **Note: this option will be removed in future, when support of ZeroMQ is terminated** 
+* `---grpc`. When `--grpc` flag is set, application runs gRPC client instead of ZeroMQ (default). **Note: this option will be removed in future, when support of ZeroMQ is terminated**
 
-## Using gulp.js
-The SPARK MAX Client repository comes with some pre-built gulpfile commands that may help during development.
+## Troubleshooting
+
+* All application errors are written into log files and can be found in the home application directory. For example for Windows operating system, you can look into `C:\Users\<user name>\AppData\Roaming\REV SPARK MAX Client\logs` directory.
+* If `electron` application is crashed, corresponding crash report can be found in the temporary directory. For example for Windows operating system, you can look into `C:\Users\<user name>\AppData\Local\Temp\SPARK MAX Client Crashes` directory.     
 
 ## SPARK MAX Client Changelog
 For detailed descriptions on what's changed between versions, head over to the repository's [CHANGELOG.md](https://github.com/REVrobotics/SPARK-MAX-Client/blob/master/CHANGELOG.md).

--- a/public/electron.ts
+++ b/public/electron.ts
@@ -1,16 +1,25 @@
-import { app, BrowserWindow, ipcMain } from "electron";
+import { app, BrowserWindow, crashReporter, ipcMain } from "electron";
 import * as path from "path";
 import { HEADLESS } from './program-args';
 import {setTargetWindow} from "./main/services/ipc-main-calls";
 
 let mainWindow: Electron.BrowserWindow;
 
+const crashReporterOptions = {
+  productName: "SPARK MAX Client",
+  companyName: "REV Robotics",
+  uploadToServer: false,
+  submitURL: "",
+};
+crashReporter.start(crashReporterOptions);
+
 if (process.env.NODE_ENV !== "production") {
   require("electron-debug")({showDevTools: true});
 }
 
-// the following value is read in the renderer process
+// the following values are read in the renderer process
 (global as any).headless = HEADLESS;
+(global as any).crashReporterOptions = crashReporterOptions;
 
 /**
  * Simply put, creates the main window that our application resides in. Technically, this function can be called

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,8 +26,11 @@ const applicationStore = createStore(
   composeEnhancers(applyMiddleware(reduxScheduler(actionSchedule), errorHandler, thunk)));
 // read value passed from the main process
 const electron = (window as any).require("electron");
-const {remote} = electron;
+const {remote, crashReporter} = electron;
 const headless = !remote.getGlobal("remote");
+const crashReporterOptions = remote.getGlobal("crashReporterOptions");
+
+crashReporter.start(crashReporterOptions);
 
 if (headless) {
   ReactDOM.render(


### PR DESCRIPTION
This PR implements support of crash reports. If `electron` application crashes you can find crash report in the temporary directory