### PR TITLE
Fix problem when user runs device for can id existing for several descriptors

### DIFF
--- a/src/store/actions/display-actions.ts
+++ b/src/store/actions/display-actions.ts
@@ -11,6 +11,7 @@ import {
 import {SparkAction} from "./action-types";
 import {forSelectedDevice} from "./action-creators";
 import {
+  queryConnectedDescriptor,
   queryControlValueByDeviceId,
   queryDestinations,
   queryDeviceId,
@@ -253,6 +254,7 @@ const syncDataProducers = (): SparkAction<Promise<void>> =>
       const runningDeviceIds = queryRunningVirtualDeviceIds(getState())
         .map((virtualDeviceId) => queryDeviceId(getState(), virtualDeviceId)!)
         .map(toDtoDeviceId);
+      const connectedDescriptor = queryConnectedDescriptor(getState());
       // Take all destinations of running devices
       const destinationsForRunningDevices = querySignalDestinations(getState())
         .filter(({deviceId}) => runningDeviceIds.includes(deviceId));
@@ -263,7 +265,10 @@ const syncDataProducers = (): SparkAction<Promise<void>> =>
       const deviceIdDiff = diffArrays(previousRunningDeviceIds, runningDeviceIds);
 
       deviceIdDiff.added.forEach((deviceId) => {
-        SparkManager.enableHeartbeat(deviceId, queryControlValueByDeviceId(getState(), fromDtoDeviceId(deviceId)), 40);
+        SparkManager.enableHeartbeat(deviceId, queryControlValueByDeviceId(
+          getState(),
+          connectedDescriptor!,
+          fromDtoDeviceId(deviceId)), 40);
       });
       deviceIdDiff.removed.forEach((deviceId) => SparkManager.disableHeartbeat(deviceId));
 

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -655,8 +655,10 @@ export const queryLastRunningDeviceIds = (state: IApplicationState): DeviceId[] 
 /**
  * Returns control value by device ID
  */
-export const queryControlValueByDeviceId = (state: IApplicationState, deviceId: DeviceId) => {
-  const device = first(queryDevicesByDeviceId(state, deviceId));
+export const queryControlValueByDeviceId = (state: IApplicationState,
+                                            descriptor: PathDescriptor,
+                                            deviceId: DeviceId) => {
+  const device = find(queryDevicesByDeviceId(state, deviceId), (found) => found.descriptor === descriptor);
   return device ? queryDeviceDisplay(state, getVirtualDeviceId(device)).run.value : 0;
 };
 


### PR DESCRIPTION
Sometimes device cannot be run when the same device id is used by several descriptors