### PR TITLE
[REVROBO-40] Safely modify CAN ID

### DIFF
--- a/src/managers/SparkManager.ts
+++ b/src/managers/SparkManager.ts
@@ -2,9 +2,11 @@ import {ConfigParam} from "../models/ConfigParam";
 import {
   FirmwareResponseDto,
   getErrorText,
-  hasError, ISignalDestinationDto,
+  hasError,
+  ISignalDestinationDto,
   ListRequestDto,
-  ListResponseDto, TelemetryEvent,
+  ListResponseDto,
+  TelemetryEvent,
   TelemetryListResponseDto
 } from "../models/dto";
 import {onCallback, sendOneWay, sendTwoWay} from "./ipc-renderer-calls";
@@ -204,7 +206,10 @@ class SparkManager {
                                   parameter: ConfigParam,
                                   value: number | string | boolean): Promise<IServerResponse> {
     const setResponse: any = await this.setParameter(device, parameter, value);
-    const getResponse: any = await this.getParameter(device, parameter);
+    // TODO: Often getParameter call returns error when it follows setParameter call and CAN ID was just modified.
+    //       We do not get CAN ID from the server in this case (as for other parameters) to make UI work as expected.
+    //       Potentially we can hide real error.
+    const getResponse: any = parameter === ConfigParam.kCanID ? value : await this.getParameter(device, parameter);
     return {requestValue: value, responseValue: getResponse, status: setResponse.status, type: setResponse.type};
   }
 

--- a/src/store/actions/action-schedule.ts
+++ b/src/store/actions/action-schedule.ts
@@ -7,12 +7,14 @@ const setCanIdProcessor = asComposed(
   // Group tasks by device
   asLeastCommits((task) => task.parameters[0]),
   // Exclusive access mode is turned on for tasks suitable for single device
-  asExclusive((test, current) => test.parameters[0] === current.parameters[0]));
+  asExclusive((test, current) => test.selector === "sync" || test.parameters[0] === current.parameters[0]));
 
 // Exclusive access mode is turned on for tasks suitable for single device
 // const setCanIdProcessor = asExclusive((test, current) => test.parameters[0] === current.parameters[0]);
 
 const schedule = {
+  // Run synchronization of devices always as only task
+  "sync": asExclusive(stubTrue),
   "set-parameter": asCond(
     // Use exclusive access for settings of CanID parameter
     [(task) => task.parameters[1] === ConfigParam.kCanID, setCanIdProcessor],

--- a/src/store/actions/connection-actions.ts
+++ b/src/store/actions/connection-actions.ts
@@ -32,6 +32,7 @@ import {SparkAction} from "./action-types";
 import {showToastWarning} from "./ui-actions";
 import {onError, useErrorHandler} from "./error-actions";
 import {syncSignals} from "./display-actions";
+import {onSchedule} from "../../utils/redux-scheduler/action";
 
 export function connectDevice(descriptor: PathDescriptor): SparkAction<Promise<void>> {
   return (dispatch, getState) => {
@@ -115,7 +116,7 @@ export function disconnectCurrentDevice(): SparkAction<Promise<any>> {
 }
 
 export function syncDevices(showNotifications: boolean = false): SparkAction<Promise<void>> {
-  return (dispatch, getState) => {
+  return onSchedule("sync", (dispatch, getState) => {
     const descriptor = queryConnectedDescriptor(getState());
     // Update status of all devices for the given descriptor
     dispatch(updateGlobalProcessStatus(tt("lbl_status_syncing")));
@@ -177,7 +178,7 @@ export function syncDevices(showNotifications: boolean = false): SparkAction<Pro
         }
       })
       .catch(useErrorHandler(dispatch));
-  };
+  });
 }
 
 export const selectDevice = (virtualDeviceId: VirtualDeviceId): SparkAction<Promise<any>> =>

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -4,7 +4,7 @@
 
 import {IServerResponse} from "../managers/SparkManager";
 import {Intent} from "@blueprintjs/core";
-import {find, keyBy, partition, sortBy, uniqueId} from "lodash";
+import {find, keyBy, padStart, partition, sortBy, uniqueId} from "lodash";
 import {ConfigParam, ConfigParamGroupId, configParamNames, getConfigParamName} from "../models/ConfigParam";
 import {
   ConfigParamGroupName,
@@ -725,6 +725,10 @@ export const isDeviceBlocked = (device: IDeviceState) => getDeviceBlockedReason(
  */
 // tslint:disable-next-line:no-bitwise
 export const getCanIdFromDeviceId = (device: DeviceId) => device % 100;
+/**
+ * Returns device ID for SPARK MAX controller using its CAN ID
+ */
+export const getSparkmaxDeviceIdFromCanId = (canId: number) => `205${padStart(String(canId), 2, "0")}`;
 
 /**
  * Analyzes two set of devices and determines which device was added, updated or removed

--- a/src/utils/redux-scheduler/processors.ts
+++ b/src/utils/redux-scheduler/processors.ts
@@ -15,22 +15,22 @@ export const asDebounce = (toKey: (task: IScheduledTask) => string,
   const keyToTimeout: {[key: string]: {timeout: any, task: IScheduledTask}} = {};
 
   return (schedule, task, next) => {
-    schedule.waitOnLock(task).then(() => {
-      const key = toKey(task);
+    const key = toKey(task);
 
-      const entry = keyToTimeout[key];
-      if (entry != null) {
-        schedule.cancel(entry.task);
-        clearTimeout(entry.timeout);
-      }
-      keyToTimeout[key] = {
-        timeout: setTimeout(() => {
+    const entry = keyToTimeout[key];
+    if (entry != null) {
+      schedule.cancel(entry.task);
+      clearTimeout(entry.timeout);
+    }
+    keyToTimeout[key] = {
+      timeout: setTimeout(() => {
+        schedule.waitOnLock(task).then(() => {
           delete keyToTimeout[key];
           next();
-        }, ms),
-        task,
-      };
-    });
+        });
+      }, ms),
+      task,
+    };
   };
 };
 


### PR DESCRIPTION
When user modifies CAN ID and other parameters too rapid, client sends several requests simultaneously to update CAN ID and other parameters.
If request to modify CAN ID was the first one, the second request to update another parameter passes old device ID.
This PR implements scheduling of "set-param" requests to avoid this issue.